### PR TITLE
Fix the method calling order

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -41621,18 +41621,6 @@ try {
         return;
     }
 
-    if (isBuildFailure(steps)) {
-        (async () => {
-            try {
-                const accessToken = await getAccessToken();
-                await sendAlert(accessToken);
-            } catch (error) {
-                console.error('Error', error);
-                console.log("choreo-build-failure-alert-send", "failed");
-            }
-        })();
-    }
-
     const isBuildFailure = (steps) => {
         for (const [stepName, stepInfo] of Object.entries(steps)) {
             if (stepInfo.outcome === 'failure') {
@@ -41711,6 +41699,18 @@ try {
             }
         }
     }
+
+    if (isBuildFailure(steps)) {
+      (async () => {
+          try {
+              const accessToken = await getAccessToken();
+              await sendAlert(accessToken);
+          } catch (error) {
+              console.error('Error', error);
+              console.log("choreo-build-failure-alert-send", "failed");
+          }
+      })();
+  }
 } catch (e) {
     console.log("choreo-build-failure-alert-send", "failed");
     console.log("choreo-build-failure-alert-send", e.message);

--- a/index.js
+++ b/index.js
@@ -30,18 +30,6 @@ try {
         return;
     }
 
-    if (isBuildFailure(steps)) {
-        (async () => {
-            try {
-                const accessToken = await getAccessToken();
-                await sendAlert(accessToken);
-            } catch (error) {
-                console.error('Error', error);
-                console.log("choreo-build-failure-alert-send", "failed");
-            }
-        })();
-    }
-
     const isBuildFailure = (steps) => {
         for (const [stepName, stepInfo] of Object.entries(steps)) {
             if (stepInfo.outcome === 'failure') {
@@ -120,6 +108,18 @@ try {
             }
         }
     }
+
+    if (isBuildFailure(steps)) {
+      (async () => {
+          try {
+              const accessToken = await getAccessToken();
+              await sendAlert(accessToken);
+          } catch (error) {
+              console.error('Error', error);
+              console.log("choreo-build-failure-alert-send", "failed");
+          }
+      })();
+  }
 } catch (e) {
     console.log("choreo-build-failure-alert-send", "failed");
     console.log("choreo-build-failure-alert-send", e.message);


### PR DESCRIPTION
Fixing the issue `choreo-build-failure-alert-send Cannot access 'isBuildFailure' before initialization` by refactoring the order.

Related: https://github.com/wso2-enterprise/choreo/issues/32295